### PR TITLE
Simple Fix for |DataDirectory| used in ConnectionString

### DIFF
--- a/SQLite.CodeFirst/SqliteInitializerBase.cs
+++ b/SQLite.CodeFirst/SqliteInitializerBase.cs
@@ -13,6 +13,15 @@ namespace SQLite.CodeFirst
         protected SqliteInitializerBase(string connectionString, DbModelBuilder modelBuilder)
         {
             DatabaseFilePath = SqliteConnectionStringParser.GetDataSource(connectionString);
+
+            var dataDirectory = AppDomain.CurrentDomain.GetData("DataDirectory") as string;
+            if (!string.IsNullOrWhiteSpace(dataDirectory))
+            {
+              var separator = Path.DirectorySeparatorChar.ToString();
+              if (!dataDirectory.EndsWith(separator)) dataDirectory += separator;
+              DatabaseFilePath = DatabaseFilePath.Replace("|DataDirectory|", dataDirectory);
+            }
+      
             ModelBuilder = modelBuilder;
 
             // This convention will crash the SQLite Provider before "InitializeDatabase" gets called.


### PR DESCRIPTION
Hi, I use your code in my ASP.NET website and i notice that my connectionstrings gave me error on 2nd run (table already exists). Here a very simple fix for |DataDirectory| in Data Source. Feel free to change the code if you don't like it ;)
