### PR TITLE
Fix IndexOutOfRangeException when connection string format end with ';' 

### DIFF
--- a/SQLite.CodeFirst/SqliteConnectionStringParser.cs
+++ b/SQLite.CodeFirst/SqliteConnectionStringParser.cs
@@ -20,7 +20,9 @@ namespace SQLite.CodeFirst
             foreach (var keyValuePair in keyValuePairs)
             {
                 string[] keyValue = keyValuePair.Split(KeyValueSeperator);
-                keyValuePairDictionary.Add(keyValue[KeyPosition].ToLower(), keyValue[ValuePosition]);
+                if (keyValue.Length >= 2){
+                    keyValuePairDictionary.Add(keyValue[KeyPosition].ToLower(), keyValue[ValuePosition]);
+                }
             }
 
             return keyValuePairDictionary;


### PR DESCRIPTION
Fix IndexOutOfRangeException when connection string format end with ';' or have unqualified key-value format.
