### PR TITLE
Fixes pluralization issue

### DIFF
--- a/SQLite.CodeFirst/Builder/CreateDatabaseStatementBuilder.cs
+++ b/SQLite.CodeFirst/Builder/CreateDatabaseStatementBuilder.cs
@@ -25,21 +25,21 @@ namespace SQLite.CodeFirst.Builder
 
         private IEnumerable<CreateTableStatement> GetCreateTableStatements()
         {
-            foreach (var entityType in edmModel.EntityTypes)
+            foreach (var entitySet in edmModel.Container.EntitySets)
             {
                 ICollection<AssociationType> associationTypes =
-                    edmModel.AssociationTypes.Where(a => a.Constraint.ToRole.Name == entityType.Name).ToList();
+                    edmModel.AssociationTypes.Where(a => a.Constraint.ToRole.Name == entitySet.Name).ToList();
 
-                var tableStatementBuilder = new CreateTableStatementBuilder(entityType, associationTypes);
+                var tableStatementBuilder = new CreateTableStatementBuilder(entitySet, associationTypes);
                 yield return tableStatementBuilder.BuildStatement();
             }
         }
 
         private IEnumerable<CreateIndexStatementCollection> GetCreateIndexStatements()
         {
-            foreach (var entityType in edmModel.EntityTypes)
+            foreach (var entitySet in edmModel.Container.EntitySets)
             {
-                var indexStatementBuilder = new CreateIndexStatementBuilder(entityType);
+                var indexStatementBuilder = new CreateIndexStatementBuilder(entitySet);
                 yield return indexStatementBuilder.BuildStatement();
             }
         }

--- a/SQLite.CodeFirst/Builder/CreateIndexStatementBuilder.cs
+++ b/SQLite.CodeFirst/Builder/CreateIndexStatementBuilder.cs
@@ -4,25 +4,24 @@ using System.ComponentModel.DataAnnotations.Schema;
 using System.Data.Entity.Core.Metadata.Edm;
 using System.Data.Entity.Infrastructure.Annotations;
 using System.Linq;
-using SQLite.CodeFirst.Extensions;
 using SQLite.CodeFirst.Statement;
 
 namespace SQLite.CodeFirst.Builder
 {
     internal class CreateIndexStatementBuilder : IStatementBuilder<CreateIndexStatementCollection>
     {
-        private readonly EntityType entityType;
+        private readonly EntitySet entitySet;
 
-        public CreateIndexStatementBuilder(EntityType entityType)
+        public CreateIndexStatementBuilder(EntitySet entitySet)
         {
-            this.entityType = entityType;
+            this.entitySet = entitySet;
         }
 
         public CreateIndexStatementCollection BuildStatement()
         {
             IDictionary<string, CreateIndexStatement> createIndexStatments = new Dictionary<string, CreateIndexStatement>();
 
-            foreach (var edmProperty in entityType.Properties)
+            foreach (var edmProperty in entitySet.ElementType.Properties)
             {
                 var indexAnnotations = edmProperty.MetadataProperties
                     .Select(x => x.Value)
@@ -38,7 +37,7 @@ namespace SQLite.CodeFirst.Builder
                         {
                             IsUnique = index.IsUnique,
                             Name = indexName,
-                            Table = entityType.GetTableName(),
+                            Table = entitySet.Table,
                             Columns = new Collection<CreateIndexStatement.IndexColumn>()
                         };
                         createIndexStatments.Add(indexName, createIndexStatement);

--- a/SQLite.CodeFirst/Builder/CreateTableStatementBuilder.cs
+++ b/SQLite.CodeFirst/Builder/CreateTableStatementBuilder.cs
@@ -7,19 +7,19 @@ namespace SQLite.CodeFirst.Builder
 {
     internal class CreateTableStatementBuilder : IStatementBuilder<CreateTableStatement>
     {
-        private readonly EntityType entityType;
+        private readonly EntitySet entitySet;
         private readonly IEnumerable<AssociationType> associationTypes;
 
-        public CreateTableStatementBuilder(EntityType entityType, IEnumerable<AssociationType> associationTypes)
+        public CreateTableStatementBuilder(EntitySet entitySet, IEnumerable<AssociationType> associationTypes)
         {
-            this.entityType = entityType;
+            this.entitySet = entitySet;
             this.associationTypes = associationTypes;
         }
 
         public CreateTableStatement BuildStatement()
         {
-            var simpleColumnCollection = new ColumnStatementCollectionBuilder(entityType.Properties).BuildStatement();
-            var primaryKeyStatement = new PrimaryKeyStatementBuilder(entityType.KeyMembers).BuildStatement();
+            var simpleColumnCollection = new ColumnStatementCollectionBuilder(entitySet.ElementType.Properties).BuildStatement();
+            var primaryKeyStatement = new PrimaryKeyStatementBuilder(entitySet.ElementType.KeyMembers).BuildStatement();
             var foreignKeyCollection = new ForeignKeyStatementBuilder(associationTypes).BuildStatement();
 
             var columnStatements = new List<IStatement>();
@@ -29,7 +29,7 @@ namespace SQLite.CodeFirst.Builder
 
             return new CreateTableStatement
             {
-                TableName = entityType.GetTableName(),
+                TableName = entitySet.Table,
                 ColumnStatementCollection = new ColumnStatementCollection(columnStatements)
             };
         }


### PR DESCRIPTION
Fixes #30 : use storage types instead of entity types

For the example project, this will generate the exact same database file from before this fix.
If you remove this line from the example project (in the FootballDbContext class) :

```
modelBuilder.Conventions.Remove<PluralizingTableNameConvention>();
```

it will now also succesfully generate pluralized table names in the database: Stadions and Teams (except for Player, because that entity has a fixed table name link to "TeamPlayer": this table is still named TeamPlayer)
