### PR TITLE
Fix incorrect path returned when dbpath has quotation mark.

### DIFF
--- a/SQLite.CodeFirst/SqliteConnectionStringParser.cs
+++ b/SQLite.CodeFirst/SqliteConnectionStringParser.cs
@@ -31,6 +31,8 @@ namespace SQLite.CodeFirst
         public static string GetDataSource(string connectionString)
         {
             var path = ExpandDataDirectory(ParseSqliteConnectionString(connectionString)["data source"]);
+            // remove quotation mark if exists
+            path = path.Trim('"');
             return path;
         }
 


### PR DESCRIPTION
Hi, Marc.

I found the issue and fixed. Would you merge to master?
TestCode is the bellow:

``` cs
builder = new SQLiteConnectionStringBuilder()
{
    DataSource = "Has QuotationMark.db",
};
Assert.AreEqual( builder.DataSource, SqliteConnectionStringParser.GetDataSource( builder.ConnectionString ) );
```
