### PR TITLE
Prefix index name with name of containing table to ensure uniqueness.

### DIFF
--- a/SQLite.CodeFirst.Console/Entity/Player.cs
+++ b/SQLite.CodeFirst.Console/Entity/Player.cs
@@ -8,7 +8,7 @@ namespace SQLite.CodeFirst.Console.Entity
     {
         public int Id { get; set; }
 
-        [Index] // Automatically named 'IX_FirstName'
+        [Index] // Automatically named 'IX_TeamPlayer_FirstName'
         [MaxLength(50)]
         public string FirstName { get; set; }
 

--- a/SQLite.CodeFirst/Builder/CreateIndexStatementBuilder.cs
+++ b/SQLite.CodeFirst/Builder/CreateIndexStatementBuilder.cs
@@ -4,6 +4,7 @@ using System.ComponentModel.DataAnnotations.Schema;
 using System.Data.Entity.Core.Metadata.Edm;
 using System.Data.Entity.Infrastructure.Annotations;
 using System.Linq;
+using SQLite.CodeFirst.Extensions;
 using SQLite.CodeFirst.Statement;
 
 namespace SQLite.CodeFirst.Builder
@@ -54,9 +55,9 @@ namespace SQLite.CodeFirst.Builder
             return new CreateIndexStatementCollection(createIndexStatments.Values);
         }
 
-        private static string GetIndexName(IndexAttribute index, EdmProperty property)
+        private string GetIndexName(IndexAttribute index, EdmProperty property)
         {
-            return index.Name ?? "IX_" + property.Name;
+            return index.Name ?? string.Format("IX_{0}_{1}", entitySet.ElementType.GetTableName(), property.Name);
         }
     }
 }


### PR DESCRIPTION
Prefixes the name of an index with the name of the table that contains the column it is created on.  No changes are made to indexes that are defined explicitly via the fluent API or `IndexAttribute`.

Fixes #35.

When you define at least two classes containing navigation properties to a common third class, and both navigation properties are mapped (via convention) to properties with identical names, the following error is received:

```
index IX_<PropertyName> already exists
```

This occurs because Entity Framework will automatically create an `index` for the non-source columns participating in a foreign-key relationship.  This is done to improve the performance when querying against the relevant columns.

Here's some code that should allow you to reproduce the issue:

``` csharp

public class Category 
{
    public int CategoryID {get; set;}
    public string CategoryName {get; set;}
}

public class Thing
{
    public int ThingID {get; set;}
    public string ThingName {get; set;}

    // Implicitly creates an index named "IX_CategoryID"
    public int CategoryID {get; set;} 
    public virtual Category Category {get; set;}
}

public class Stuff
{
    public int StuffID {get; set;}
    public string StuffName {get; set;}

    // Attempts to create another index, also named "IX_CategoryID"
    // As this index was already created earlier, we get an error:
    // "index IX_CategoryID already exists"
    public int CategoryID {get; set;} 
    public virtual Category Category {get; set;}
}

```
