### PR TITLE
Allow for a missing datasource

### DIFF
--- a/SQLite.CodeFirst.Console/Entity/Person.cs
+++ b/SQLite.CodeFirst.Console/Entity/Person.cs
@@ -1,4 +1,6 @@
-﻿using System.ComponentModel.DataAnnotations;
+﻿using System;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
 
 namespace SQLite.CodeFirst.Console.Entity
 {
@@ -18,5 +20,9 @@ namespace SQLite.CodeFirst.Console.Entity
 
         [Required]
         public string City { get; set; }
+
+        [DatabaseGenerated(DatabaseGeneratedOption.Computed)]
+        [SqlDefaultValue(DefaultValue = "DATETIME('now')")]
+        public DateTime CreatedUtc { get; set; }
     }
 }

--- a/SQLite.CodeFirst.Console/Program.cs
+++ b/SQLite.CodeFirst.Console/Program.cs
@@ -131,6 +131,7 @@ namespace SQLite.CodeFirst.Console
                     System.Console.WriteLine("\t\t LastName: {0}", player.LastName);
                     System.Console.WriteLine("\t\t Street: {0}", player.Street);
                     System.Console.WriteLine("\t\t City: {0}", player.City);
+                    System.Console.WriteLine("\t\t Created: {0}", player.CreatedUtc);
                     System.Console.WriteLine();
                 }
             }

--- a/SQLite.CodeFirst.Test/IntegrationTests/SqlGenerationTest.cs
+++ b/SQLite.CodeFirst.Test/IntegrationTests/SqlGenerationTest.cs
@@ -15,8 +15,8 @@ namespace SQLite.CodeFirst.Test.IntegrationTests
     {
         private const string ReferenceSql =
             @"CREATE TABLE ""MyTable"" ([Id] INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, [Name] nvarchar NOT NULL, FOREIGN KEY (Id) REFERENCES ""Coaches""(Id));
-CREATE TABLE ""Coaches"" ([Id] INTEGER PRIMARY KEY, [FirstName] nvarchar (50) COLLATE NOCASE, [LastName] nvarchar (50), [Street] nvarchar (100), [City] nvarchar NOT NULL);
-CREATE TABLE ""TeamPlayer"" ([Id] INTEGER PRIMARY KEY, [Number] int NOT NULL, [TeamId] int NOT NULL, [FirstName] nvarchar (50) COLLATE NOCASE, [LastName] nvarchar (50), [Street] nvarchar (100), [City] nvarchar NOT NULL, [Mentor_Id] int, FOREIGN KEY (Mentor_Id) REFERENCES ""TeamPlayer""(Id), FOREIGN KEY (TeamId) REFERENCES ""MyTable""(Id) ON DELETE CASCADE);
+CREATE TABLE ""Coaches"" ([Id] INTEGER PRIMARY KEY, [FirstName] nvarchar (50) COLLATE NOCASE, [LastName] nvarchar (50), [Street] nvarchar (100), [City] nvarchar NOT NULL, [CreatedUtc] datetime NOT NULL DEFAULT (DATETIME('now')));
+CREATE TABLE ""TeamPlayer"" ([Id] INTEGER PRIMARY KEY, [Number] int NOT NULL, [TeamId] int NOT NULL, [FirstName] nvarchar (50) COLLATE NOCASE, [LastName] nvarchar (50), [Street] nvarchar (100), [City] nvarchar NOT NULL, [CreatedUtc] datetime NOT NULL DEFAULT (DATETIME('now')), [Mentor_Id] int, FOREIGN KEY (Mentor_Id) REFERENCES ""TeamPlayer""(Id), FOREIGN KEY (TeamId) REFERENCES ""MyTable""(Id) ON DELETE CASCADE);
 CREATE TABLE ""Stadions"" ([Name] nvarchar (128) NOT NULL, [Street] nvarchar (128) NOT NULL, [City] nvarchar (128) NOT NULL, [Team_Id] int NOT NULL, PRIMARY KEY(Name, Street, City), FOREIGN KEY (Team_Id) REFERENCES ""MyTable""(Id) ON DELETE CASCADE);
 CREATE TABLE ""Foos"" ([FooId] INTEGER PRIMARY KEY, [Name] nvarchar, [FooSelf1Id] int, [FooSelf2Id] int, [FooSelf3Id] int, FOREIGN KEY (FooSelf1Id) REFERENCES ""Foos""(FooId), FOREIGN KEY (FooSelf2Id) REFERENCES ""Foos""(FooId), FOREIGN KEY (FooSelf3Id) REFERENCES ""Foos""(FooId));
 CREATE TABLE ""FooSelves"" ([FooSelfId] INTEGER PRIMARY KEY, [FooId] int NOT NULL, [Number] int NOT NULL, FOREIGN KEY (FooId) REFERENCES ""Foos""(FooId) ON DELETE CASCADE);
@@ -37,11 +37,11 @@ CREATE  INDEX ""IX_FooStep_FooId"" ON ""FooSteps"" (FooId);";
         private static string generatedSql;
 
         // Does not work on the build server. No clue why.
-        [Ignore]
+        
         [TestMethod]
         public void SqliteSqlGeneratorTest()
         {
-            using (DbConnection connection = new SQLiteConnection("data source=:memory:"))
+            using (DbConnection connection = new SQLiteConnection("FullUri=file::memory:"))
             {
                 // This is important! Else the in memory database will not work.
                 connection.Open();
@@ -51,7 +51,7 @@ CREATE  INDEX ""IX_FooStep_FooId"" ON ""FooSteps"" (FooId);";
                     // ReSharper disable once UnusedVariable
                     Player fo = context.Set<Player>().FirstOrDefault();
 
-                    Assert.IsTrue(string.Equals(RemoveLineEndings(ReferenceSql), RemoveLineEndings(generatedSql)));
+                    Assert.AreEqual(RemoveLineEndings(ReferenceSql), RemoveLineEndings(generatedSql));
                 }
             }
         }

--- a/SQLite.CodeFirst.Test/SQLite.CodeFirst.Test.csproj
+++ b/SQLite.CodeFirst.Test/SQLite.CodeFirst.Test.csproj
@@ -98,6 +98,7 @@
     <Compile Include="UnitTests\Statement\ColumnConstraint\ColumnConstraintCollectionTest.cs" />
     <Compile Include="UnitTests\Statement\ColumnConstraint\NotNullConstraintTest.cs" />
     <Compile Include="UnitTests\Statement\ColumnConstraint\CollateConstraintTest.cs" />
+    <Compile Include="UnitTests\Statement\ColumnConstraint\DefaultValueConstraintTest.cs" />
     <Compile Include="UnitTests\Statement\ColumnConstraint\UniqueConstraintTest.cs" />
     <Compile Include="UnitTests\Statement\ColumnStatementCollectionTest.cs" />
     <Compile Include="UnitTests\Statement\PrimaryKeyStatementTest.cs" />

--- a/SQLite.CodeFirst.Test/UnitTests/Statement/ColumnConstraint/DefaultValueConstraintTest.cs
+++ b/SQLite.CodeFirst.Test/UnitTests/Statement/ColumnConstraint/DefaultValueConstraintTest.cs
@@ -12,7 +12,7 @@ namespace SQLite.CodeFirst.Test.UnitTests.Statement.ColumnConstraint
             var defaultValueConstraint = new DefaultValueConstraint();
             defaultValueConstraint.DefaultValue = "0";
             string output = defaultValueConstraint.CreateStatement();
-            Assert.AreEqual(output, "DEFAULT 0");
+            Assert.AreEqual(output, "DEFAULT (0)");
         }
 
         [TestMethod]
@@ -21,14 +21,14 @@ namespace SQLite.CodeFirst.Test.UnitTests.Statement.ColumnConstraint
             var defaultValueConstraint = new DefaultValueConstraint();
             defaultValueConstraint.DefaultValue = @"'Something'";
             string output = defaultValueConstraint.CreateStatement();
-            Assert.AreEqual(output, "DEFAULT 'Something'");
+            Assert.AreEqual(output, "DEFAULT ('Something')");
         }
 
         [TestMethod]
         public void CreateStatement_StatementIsCorrect_ExpressionDefault()
         {
             var defaultValueConstraint = new DefaultValueConstraint();
-            defaultValueConstraint.DefaultValue = @"(datetime('now'))";
+            defaultValueConstraint.DefaultValue = @"datetime('now')";
             string output = defaultValueConstraint.CreateStatement();
             Assert.AreEqual(output, "DEFAULT (datetime('now'))");
         }

--- a/SQLite.CodeFirst.Test/UnitTests/Statement/ColumnConstraint/DefaultValueConstraintTest.cs
+++ b/SQLite.CodeFirst.Test/UnitTests/Statement/ColumnConstraint/DefaultValueConstraintTest.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SQLite.CodeFirst.Statement.ColumnConstraint;
+
+namespace SQLite.CodeFirst.Test.UnitTests.Statement.ColumnConstraint
+{
+    [TestClass]
+    public class DefaultValueConstraintTest
+    {
+        [TestMethod]
+        public void CreateStatement_StatementIsCorrect_IntDefault()
+        {
+            var defaultValueConstraint = new DefaultValueConstraint();
+            defaultValueConstraint.DefaultValue = "0";
+            string output = defaultValueConstraint.CreateStatement();
+            Assert.AreEqual(output, "DEFAULT 0");
+        }
+
+        [TestMethod]
+        public void CreateStatement_StatementIsCorrect_StringDefault()
+        {
+            var defaultValueConstraint = new DefaultValueConstraint();
+            defaultValueConstraint.DefaultValue = @"'Something'";
+            string output = defaultValueConstraint.CreateStatement();
+            Assert.AreEqual(output, "DEFAULT 'Something'");
+        }
+
+        [TestMethod]
+        public void CreateStatement_StatementIsCorrect_ExpressionDefault()
+        {
+            var defaultValueConstraint = new DefaultValueConstraint();
+            defaultValueConstraint.DefaultValue = @"(datetime('now'))";
+            string output = defaultValueConstraint.CreateStatement();
+            Assert.AreEqual(output, "DEFAULT (datetime('now'))");
+        }
+    }
+}

--- a/SQLite.CodeFirst/Internal/Builder/ColumnStatementCollectionBuilder.cs
+++ b/SQLite.CodeFirst/Internal/Builder/ColumnStatementCollectionBuilder.cs
@@ -41,6 +41,7 @@ namespace SQLite.CodeFirst.Builder
                 AddUniqueConstraintIfNecessary(property, columnStatement);
                 AddCollationConstraintIfNecessary(property, columnStatement);
                 AddPrimaryKeyConstraintAndAdjustTypeIfNecessary(property, columnStatement);
+                AddDefaultValueConstraintIfNecessary(property, columnStatement);
 
                 yield return columnStatement;
             }
@@ -87,6 +88,15 @@ namespace SQLite.CodeFirst.Builder
             if (value != null)
             {
                 columnStatement.ColumnConstraints.Add(new UniqueConstraint { OnConflict = value.OnConflict });
+            }
+        }
+
+        private static void AddDefaultValueConstraintIfNecessary(EdmProperty property, ColumnStatement columnStatement)
+        {
+            var value = property.GetCustomAnnotation<SqlDefaultValueAttribute>();
+            if (value != null)
+            {
+                columnStatement.ColumnConstraints.Add(new DefaultValueConstraint { DefaultValue = value.DefaultValue });
             }
         }
 

--- a/SQLite.CodeFirst/Internal/Statement/ColumnConstraint/DefaultValueConstraint.cs
+++ b/SQLite.CodeFirst/Internal/Statement/ColumnConstraint/DefaultValueConstraint.cs
@@ -1,0 +1,20 @@
+﻿using System.Text;
+
+namespace SQLite.CodeFirst.Statement.ColumnConstraint
+{
+    internal class DefaultValueConstraint : IColumnConstraint
+    {
+        private const string Template = "DEFAULT ({defaultValue})";
+
+        public string DefaultValue { get; set; }
+
+        public string CreateStatement()
+        {
+            var sb = new StringBuilder(Template);
+
+            sb.Replace("{defaultValue}", DefaultValue);
+
+            return sb.ToString().Trim();
+        }
+    }
+}

--- a/SQLite.CodeFirst/Internal/Utility/ConnectionStringParser.cs
+++ b/SQLite.CodeFirst/Internal/Utility/ConnectionStringParser.cs
@@ -17,17 +17,20 @@ namespace SQLite.CodeFirst.Utility
 
         public static string GetDataSource(string connectionString)
         {
-            // Check if the datasource token exists and return Null if it doesn't.
-            // This will allow connection strings with FullUri to work.
+            // If the datasource token does not exists this is a FullUri connection string.
             IDictionary<string, string> strings = ParseConnectionString(connectionString);
             if (strings.ContainsKey(DataSourceToken))
             {
                 var path = ExpandDataDirectory(ParseConnectionString(connectionString)[DataSourceToken]);
                 // remove quotation mark if exists
-                path = path.Trim('"');
-                return path;
+                return path.Trim('"');
             }
-            return null;
+            // TODO: Implement FullUri parsing.
+            if (connectionString.Contains(":memory:")) 
+            {
+                return ":memory:";
+            }
+            throw new NotSupportedException("FullUri format is currently only supported for :memory:.");
         }
 
         [SuppressMessage("Microsoft.Globalization", "CA1308:NormalizeStringsToUppercase", Justification = "ToUppercase makes no sense.")]

--- a/SQLite.CodeFirst/Internal/Utility/ConnectionStringParser.cs
+++ b/SQLite.CodeFirst/Internal/Utility/ConnectionStringParser.cs
@@ -17,10 +17,17 @@ namespace SQLite.CodeFirst.Utility
 
         public static string GetDataSource(string connectionString)
         {
-            var path = ExpandDataDirectory(ParseConnectionString(connectionString)[DataSourceToken]);
-            // remove quotation mark if exists
-            path = path.Trim('"');
-            return path;
+            // Check if the datasource token exists and return Null if it doesn't.
+            // This will allow connection strings with FullUri to work.
+            IDictionary<string, string> strings = ParseConnectionString(connectionString);
+            if (strings.ContainsKey(DataSourceToken))
+            {
+                var path = ExpandDataDirectory(ParseConnectionString(connectionString)[DataSourceToken]);
+                // remove quotation mark if exists
+                path = path.Trim('"');
+                return path;
+            }
+            return null;
         }
 
         [SuppressMessage("Microsoft.Globalization", "CA1308:NormalizeStringsToUppercase", Justification = "ToUppercase makes no sense.")]

--- a/SQLite.CodeFirst/Internal/Utility/InMemoryAwareFile.cs
+++ b/SQLite.CodeFirst/Internal/Utility/InMemoryAwareFile.cs
@@ -52,7 +52,9 @@ namespace SQLite.CodeFirst.Utility
 
         private static bool IsInMemoryPath(string path)
         {
-            return string.Equals(path, ":memory:", StringComparison.OrdinalIgnoreCase);
+            // If the path doesn't exists then the datasource was empty as probably a FullUri was specified instead.
+            return string.IsNullOrEmpty(path)
+                   || string.Equals(path, ":memory:", StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/SQLite.CodeFirst/Public/Attributes/SqlDefaultValueAttribute.cs
+++ b/SQLite.CodeFirst/Public/Attributes/SqlDefaultValueAttribute.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace SQLite.CodeFirst
+{
+    /// <summary>
+    /// Decorate an column with this attribute to create a "DEFAULT {defaultvalue}".
+    /// <remarks>
+    /// https://www.sqlite.org/lang_createtable.html [05.10.2017]
+    /// </remarks>
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property)]
+    public sealed class SqlDefaultValueAttribute : Attribute
+    {
+        public string DefaultValue { get; set; }
+    }
+}

--- a/SQLite.CodeFirst/Public/DbInitializers/SqliteInitializerBase.cs
+++ b/SQLite.CodeFirst/Public/DbInitializers/SqliteInitializerBase.cs
@@ -43,6 +43,7 @@ namespace SQLite.CodeFirst
             modelBuilder.RegisterAttributeAsColumnAnnotation<UniqueAttribute>();
             modelBuilder.RegisterAttributeAsColumnAnnotation<CollateAttribute>();
             modelBuilder.RegisterAttributeAsColumnAnnotation<AutoincrementAttribute>();
+            modelBuilder.RegisterAttributeAsColumnAnnotation<SqlDefaultValueAttribute>();
 
             // By default there is a 'ForeignKeyIndexConvention' but it can be removed.
             // And there is no "Contains" and no way to enumerate the ConventionsCollection.

--- a/SQLite.CodeFirst/SQLite.CodeFirst.csproj
+++ b/SQLite.CodeFirst/SQLite.CodeFirst.csproj
@@ -88,6 +88,7 @@
       <Link>Properties\AssemblySharedInfo.cs</Link>
     </Compile>
     <Compile Include="Internal\Builder\NameCreators\NameCreator.cs" />
+    <Compile Include="Internal\Statement\ColumnConstraint\DefaultValueConstraint.cs" />
     <Compile Include="Internal\Utility\InMemoryAwareFile.cs" />
     <Compile Include="Internal\Extensions\ListExtensions.cs" />
     <Compile Include="Internal\Statement\ColumnConstraint\PrimaryKeyConstraint.cs" />
@@ -95,6 +96,7 @@
     <Compile Include="Public\Attributes\CollateAttribute.cs" />
     <Compile Include="Public\Attributes\CollationFunction.cs" />
     <Compile Include="Public\Attributes\OnConflictAction.cs" />
+    <Compile Include="Public\Attributes\SqlDefaultValueAttribute.cs" />
     <Compile Include="Public\Attributes\UniqueAttribute.cs" />
     <Compile Include="Public\Entities\IHistory.cs" />
     <Compile Include="Internal\Builder\NameCreators\IndexNameCreator.cs" />


### PR DESCRIPTION
Allow for a missing datasource which means that the datasource is a FullUri like:

FullUri=file::memory:?cache=shared;Version=3

This way the in memory database can be shared over connections.