### PR TITLE
Code-based configuration for .NET Core

### DIFF
--- a/SQLite.CodeFirst.NetCore.Console/Configuration.cs
+++ b/SQLite.CodeFirst.NetCore.Console/Configuration.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Data.Entity;
+using System.Data.Entity.Core.EntityClient;
+using System.Data.Entity.Infrastructure;
+using System.Data.Entity.Infrastructure.DependencyResolution;
+using System.Data.SQLite;
+using System.Data.SQLite.EF6;
+using System.Linq;
+
+namespace SQLite.CodeFirst.Console
+{
+    public class Configuration : DbConfiguration
+    {
+        public Configuration()
+        {
+            AddDependencyResolver(SQLiteDependencyResolver.Instance);
+        }
+
+        private class SQLiteDependencyResolver : IDbDependencyResolver
+        {
+            public static IDbDependencyResolver Instance { get; }
+                = new SQLiteDependencyResolver();
+
+            public object GetService(Type type, object key)
+            {
+                return type == typeof(DbProviderFactory)
+                    ? SQLiteProviderFactory.Instance
+                    : type == typeof(IDbProviderFactoryResolver)
+                    ? SQLiteDbProviderFactoryResolver.Instance
+                    : type == typeof(IProviderInvariantName)
+                    ? SQLiteProviderInvariantName.Instance
+                    : SQLiteProviderFactory.Instance.GetService(type);
+            }
+
+            public IEnumerable<object> GetServices(Type type, object key)
+                => Enumerable.Empty<object>();
+        }
+
+        private class SQLiteDbProviderFactoryResolver : IDbProviderFactoryResolver
+        {
+            public static IDbProviderFactoryResolver Instance { get; }
+                = new SQLiteDbProviderFactoryResolver();
+
+            public DbProviderFactory ResolveProviderFactory(DbConnection connection)
+            {
+                return connection switch
+                {
+                    SQLiteConnection _ => SQLiteProviderFactory.Instance,
+                    EntityConnection _ => EntityProviderFactory.Instance,
+                    _ => null
+                };
+            }
+        }
+
+        private class SQLiteProviderInvariantName : IProviderInvariantName
+        {
+            public static IProviderInvariantName Instance { get; }
+                = new SQLiteProviderInvariantName();
+
+            public string Name { get; } = "System.Data.SQLite.EF6";
+        }
+    }
+}

--- a/SQLite.CodeFirst.NetCore.Console/Configuration.cs
+++ b/SQLite.CodeFirst.NetCore.Console/Configuration.cs
@@ -1,65 +1,28 @@
-using System;
-using System.Collections.Generic;
 using System.Data.Common;
 using System.Data.Entity;
-using System.Data.Entity.Core.EntityClient;
+using System.Data.Entity.Core.Common;
 using System.Data.Entity.Infrastructure;
-using System.Data.Entity.Infrastructure.DependencyResolution;
 using System.Data.SQLite;
 using System.Data.SQLite.EF6;
-using System.Linq;
 
 namespace SQLite.CodeFirst.Console
 {
-    public class Configuration : DbConfiguration
+    public class Configuration : DbConfiguration, IDbConnectionFactory
     {
         public Configuration()
         {
-            AddDependencyResolver(SQLiteDependencyResolver.Instance);
+            SetProviderFactory("System.Data.SQLite", SQLiteFactory.Instance);
+            SetProviderFactory("System.Data.SQLite.EF6", SQLiteProviderFactory.Instance);
+
+            var providerServices = (DbProviderServices)SQLiteProviderFactory.Instance.GetService(typeof(DbProviderServices));
+
+            SetProviderServices("System.Data.SQLite", providerServices);
+            SetProviderServices("System.Data.SQLite.EF6", providerServices);
+
+            SetDefaultConnectionFactory(this);
         }
 
-        private class SQLiteDependencyResolver : IDbDependencyResolver
-        {
-            public static IDbDependencyResolver Instance { get; }
-                = new SQLiteDependencyResolver();
-
-            public object GetService(Type type, object key)
-            {
-                return type == typeof(DbProviderFactory)
-                    ? SQLiteProviderFactory.Instance
-                    : type == typeof(IDbProviderFactoryResolver)
-                    ? SQLiteDbProviderFactoryResolver.Instance
-                    : type == typeof(IProviderInvariantName)
-                    ? SQLiteProviderInvariantName.Instance
-                    : SQLiteProviderFactory.Instance.GetService(type);
-            }
-
-            public IEnumerable<object> GetServices(Type type, object key)
-                => Enumerable.Empty<object>();
-        }
-
-        private class SQLiteDbProviderFactoryResolver : IDbProviderFactoryResolver
-        {
-            public static IDbProviderFactoryResolver Instance { get; }
-                = new SQLiteDbProviderFactoryResolver();
-
-            public DbProviderFactory ResolveProviderFactory(DbConnection connection)
-            {
-                return connection switch
-                {
-                    SQLiteConnection _ => SQLiteProviderFactory.Instance,
-                    EntityConnection _ => EntityProviderFactory.Instance,
-                    _ => null
-                };
-            }
-        }
-
-        private class SQLiteProviderInvariantName : IProviderInvariantName
-        {
-            public static IProviderInvariantName Instance { get; }
-                = new SQLiteProviderInvariantName();
-
-            public string Name { get; } = "System.Data.SQLite.EF6";
-        }
+        public DbConnection CreateConnection(string connectionString)
+            => new SQLiteConnection(connectionString);
     }
 }

--- a/SQLite.CodeFirst.NetCore.Console/Program.cs
+++ b/SQLite.CodeFirst.NetCore.Console/Program.cs
@@ -39,7 +39,7 @@ namespace SQLite.CodeFirst.Console
             System.Console.WriteLine("Starting Demo Application (File)");
             System.Console.WriteLine(string.Empty);
 
-            using (var context = new FootballDbContext("footballDb"))
+            using (var context = new FootballDbContext(@"data source=.\db\footballDb\footballDb.sqlite;foreign keys=true"))
             {
                 CreateAndSeedDatabase(context);
                 DisplaySeededData(context);

--- a/SQLite.CodeFirst.NetCore.Console/SQLite.CodeFirst.NetCore.Console.csproj
+++ b/SQLite.CodeFirst.NetCore.Console/SQLite.CodeFirst.NetCore.Console.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Data.SQLite" Version="1.0.112" />
-    <PackageReference Include="System.Data.SQLite.EF6" Version="1.0.112" />
+    <PackageReference Include="System.Data.SQLite" Version="1.0.112.2" />
+    <PackageReference Include="System.Data.SQLite.EF6" Version="1.0.112.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SQLite.CodeFirst.NetCore.Console/SQLite.CodeFirst.NetCore.Console.csproj
+++ b/SQLite.CodeFirst.NetCore.Console/SQLite.CodeFirst.NetCore.Console.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.Data.SQLite" Version="1.0.112" />
+    <PackageReference Include="System.Data.SQLite.EF6" Version="1.0.112" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Since the .NET Standard Version of `System.Data.SQLite` doesn't reference `System.Data.SQLite.EF6` we need an explicit reference for that
- Registering the whole SQLite provider stuff via *app.config* doesn't work any more and there doesn't seem to come a nice code based `IDbDependencyResolver` out-of-the-box; thus, we need to provide that too

Hope that helps