### PR TITLE
Enable embedded resource DependentUpon convention

### DIFF
--- a/SQLite.CodeFirst.MigrationConsole/SQLite.CodeFirst.MigrationConsole.csproj
+++ b/SQLite.CodeFirst.MigrationConsole/SQLite.CodeFirst.MigrationConsole.csproj
@@ -9,6 +9,13 @@
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\Shared\SQLite.CodeFirst.StrongNameKey.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
+
+  <!-- Bug with the SDK for .NET Framework projects. The resx migrations are not included
+  See: https://github.com/dotnet/ef6/issues/1258#issuecomment-531355034 -->
+  <PropertyGroup>
+    <EmbeddedResourceUseDependentUponConvention>true</EmbeddedResourceUseDependentUponConvention>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="System.Data.SQLite" Version="1.0.112.2" />
   </ItemGroup>


### PR DESCRIPTION
MSBuild builds old-style csproj as EmbeddedResourceUseDependentUponConvention is enabled, but it has been changed to be disabled in sdk-style csproj.

See: https://github.com/dotnet/ef6/issues/1258#issuecomment-531355034