### PR TITLE
Make SQLiteCodeFirst FIPS compliant

### DIFF
--- a/SQLite.CodeFirst/Internal/Utility/HashCreator.cs
+++ b/SQLite.CodeFirst/Internal/Utility/HashCreator.cs
@@ -9,7 +9,7 @@ namespace SQLite.CodeFirst.Utility
         public static string CreateHash(string data)
         {
             byte[] dataBytes = Encoding.ASCII.GetBytes(data);
-            using (SHA512 sha512 = new SHA512Managed())
+            using (SHA512 sha512 = new SHA512CryptoServiceProvider())
             {
                 byte[] hashBytes = sha512.ComputeHash(dataBytes);
                 string hash = Convert.ToBase64String(hashBytes);

--- a/SQLite.CodeFirst/Internal/Utility/HashCreator.cs
+++ b/SQLite.CodeFirst/Internal/Utility/HashCreator.cs
@@ -1,8 +1,6 @@
 ﻿using System;
-using System.Diagnostics;
 using System.Security.Cryptography;
 using System.Text;
-using System.Threading;
 
 namespace SQLite.CodeFirst.Utility
 {

--- a/SQLite.CodeFirst/Internal/Utility/HashCreator.cs
+++ b/SQLite.CodeFirst/Internal/Utility/HashCreator.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Security.Cryptography;
 using System.Text;
+using System.Threading;
 
 namespace SQLite.CodeFirst.Utility
 {
@@ -8,8 +10,13 @@ namespace SQLite.CodeFirst.Utility
     {
         public static string CreateHash(string data)
         {
+            while (!Debugger.IsAttached)
+            {
+                Thread.Sleep(100);
+            }
+
             byte[] dataBytes = Encoding.ASCII.GetBytes(data);
-            using (SHA512 sha512 = new SHA512CryptoServiceProvider())
+            using (SHA512 sha512 = SHA512.Create())
             {
                 byte[] hashBytes = sha512.ComputeHash(dataBytes);
                 string hash = Convert.ToBase64String(hashBytes);

--- a/SQLite.CodeFirst/Internal/Utility/HashCreator.cs
+++ b/SQLite.CodeFirst/Internal/Utility/HashCreator.cs
@@ -10,11 +10,6 @@ namespace SQLite.CodeFirst.Utility
     {
         public static string CreateHash(string data)
         {
-            while (!Debugger.IsAttached)
-            {
-                Thread.Sleep(100);
-            }
-
             byte[] dataBytes = Encoding.ASCII.GetBytes(data);
             using (SHA512 sha512 = SHA512.Create())
             {


### PR DESCRIPTION
This PR makes SQLiteCodeFirst FIPS compliant, needed to operate on US federal or many state government systems as it is a requirement for software vendors.

SHA512.Create() will return a new SHA512Managed instance by default. But, if FIPS restriction is enabled, it will return an FIPS-compliant instance.

What is FIPS compliance? FIPS stands for Federal Information Processing Standards and are US Government standards that provide a benchmark for implementing cryptographic software

SHA512CryptoServiceProvider uses the FIPS 140-2 validated (FIPS = Federal Information Processing Standards) Crypto Service Provider (CSP) while SHA256Managed does not.