### PR TITLE
Expose default collation through the public initializers

### DIFF
--- a/SQLite.CodeFirst.Test/UnitTests/DbInitializers/InitializerDefaultCollationTest.cs
+++ b/SQLite.CodeFirst.Test/UnitTests/DbInitializers/InitializerDefaultCollationTest.cs
@@ -1,0 +1,64 @@
+using System.Data.Entity;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SQLite.CodeFirst.NetCore.Console;
+
+namespace SQLite.CodeFirst.Test.UnitTests.DbInitializers
+{
+    /// <summary>
+    /// Verifies that the public initializers forward an explicitly supplied default
+    /// <see cref="Collation"/> to the base class, which is what feeds it into the SQL generation.
+    /// Without this the documented "default collation" feature is unreachable through the shipped initializers.
+    /// </summary>
+    [TestClass]
+    public class InitializerDefaultCollationTest
+    {
+        private static readonly Collation Collation = new Collation(CollationFunction.RTrim);
+
+        private static DbModelBuilder NewModelBuilder()
+        {
+            return new DbModelBuilder();
+        }
+
+        [TestMethod]
+        public void SqliteCreateDatabaseIfNotExists_ForwardsDefaultCollation()
+        {
+            var initializer = new SqliteCreateDatabaseIfNotExists<FootballDbContext>(NewModelBuilder(), Collation);
+            Assert.AreSame(Collation, initializer.DefaultCollation);
+        }
+
+        [TestMethod]
+        public void SqliteCreateDatabaseIfNotExists_WithNullByteFlag_ForwardsDefaultCollation()
+        {
+            var initializer = new SqliteCreateDatabaseIfNotExists<FootballDbContext>(NewModelBuilder(), true, Collation);
+            Assert.AreSame(Collation, initializer.DefaultCollation);
+        }
+
+        [TestMethod]
+        public void SqliteDropCreateDatabaseAlways_ForwardsDefaultCollation()
+        {
+            var initializer = new SqliteDropCreateDatabaseAlways<FootballDbContext>(NewModelBuilder(), Collation);
+            Assert.AreSame(Collation, initializer.DefaultCollation);
+        }
+
+        [TestMethod]
+        public void SqliteDropCreateDatabaseWhenModelChanges_ForwardsDefaultCollation()
+        {
+            var initializer = new SqliteDropCreateDatabaseWhenModelChanges<FootballDbContext>(NewModelBuilder(), Collation);
+            Assert.AreSame(Collation, initializer.DefaultCollation);
+        }
+
+        [TestMethod]
+        public void SqliteDropCreateDatabaseWhenModelChanges_WithHistoryType_ForwardsDefaultCollation()
+        {
+            var initializer = new SqliteDropCreateDatabaseWhenModelChanges<FootballDbContext>(NewModelBuilder(), typeof(History), Collation);
+            Assert.AreSame(Collation, initializer.DefaultCollation);
+        }
+
+        [TestMethod]
+        public void Initializer_WithoutCollation_HasNullDefaultCollation()
+        {
+            var initializer = new SqliteDropCreateDatabaseAlways<FootballDbContext>(NewModelBuilder());
+            Assert.IsNull(initializer.DefaultCollation);
+        }
+    }
+}

--- a/SQLite.CodeFirst/Public/DbInitializers/SqliteCreateDatabaseIfNotExists.cs
+++ b/SQLite.CodeFirst/Public/DbInitializers/SqliteCreateDatabaseIfNotExists.cs
@@ -19,7 +19,16 @@ namespace SQLite.CodeFirst
         /// </summary>
         /// <param name="modelBuilder">The model builder.</param>
         public SqliteCreateDatabaseIfNotExists(DbModelBuilder modelBuilder)
-            : this(modelBuilder, false)
+            : this(modelBuilder, false, null)
+        { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SqliteCreateDatabaseIfNotExists{TContext}"/> class.
+        /// </summary>
+        /// <param name="modelBuilder">The model builder.</param>
+        /// <param name="defaultCollation">The default collation applied to all string columns. Explicit <see cref="CollateAttribute"/>s take precedence.</param>
+        public SqliteCreateDatabaseIfNotExists(DbModelBuilder modelBuilder, Collation defaultCollation)
+            : this(modelBuilder, false, defaultCollation)
         { }
 
         /// <summary>
@@ -28,7 +37,17 @@ namespace SQLite.CodeFirst
         /// <param name="modelBuilder">The model builder.</param>
         /// <param name="nullByteFileMeansNotExisting">if set to <c>true</c> a null byte database file is treated like the database does not exist.</param>
         public SqliteCreateDatabaseIfNotExists(DbModelBuilder modelBuilder, bool nullByteFileMeansNotExisting)
-            : base(modelBuilder)
+            : this(modelBuilder, nullByteFileMeansNotExisting, null)
+        { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SqliteCreateDatabaseIfNotExists{TContext}"/> class.
+        /// </summary>
+        /// <param name="modelBuilder">The model builder.</param>
+        /// <param name="nullByteFileMeansNotExisting">if set to <c>true</c> a null byte database file is treated like the database does not exist.</param>
+        /// <param name="defaultCollation">The default collation applied to all string columns. Explicit <see cref="CollateAttribute"/>s take precedence.</param>
+        public SqliteCreateDatabaseIfNotExists(DbModelBuilder modelBuilder, bool nullByteFileMeansNotExisting, Collation defaultCollation)
+            : base(modelBuilder, defaultCollation)
         {
             this.nullByteFileMeansNotExisting = nullByteFileMeansNotExisting;
         }

--- a/SQLite.CodeFirst/Public/DbInitializers/SqliteDropCreateDatabaseAlways.cs
+++ b/SQLite.CodeFirst/Public/DbInitializers/SqliteDropCreateDatabaseAlways.cs
@@ -17,7 +17,16 @@ namespace SQLite.CodeFirst
         /// </summary>
         /// <param name="modelBuilder">The model builder.</param>
         public SqliteDropCreateDatabaseAlways(DbModelBuilder modelBuilder)
-            : base(modelBuilder)
+            : this(modelBuilder, null)
+        { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SqliteDropCreateDatabaseAlways{TContext}"/> class.
+        /// </summary>
+        /// <param name="modelBuilder">The model builder.</param>
+        /// <param name="defaultCollation">The default collation applied to all string columns. Explicit <see cref="CollateAttribute"/>s take precedence.</param>
+        public SqliteDropCreateDatabaseAlways(DbModelBuilder modelBuilder, Collation defaultCollation)
+            : base(modelBuilder, defaultCollation)
         { }
 
         /// <summary>

--- a/SQLite.CodeFirst/Public/DbInitializers/SqliteDropCreateDatabaseWhenModelChanges.cs
+++ b/SQLite.CodeFirst/Public/DbInitializers/SqliteDropCreateDatabaseWhenModelChanges.cs
@@ -34,11 +34,17 @@ namespace SQLite.CodeFirst
         /// </summary>
         /// <param name="modelBuilder">The model builder.</param>
         public SqliteDropCreateDatabaseWhenModelChanges(DbModelBuilder modelBuilder)
-            : base(modelBuilder)
-        {
-            historyEntityType = typeof(History);
-            ConfigureHistoryEntity();
-        }
+            : this(modelBuilder, typeof(History), null)
+        { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SqliteDropCreateDatabaseWhenModelChanges{TContext}"/> class.
+        /// </summary>
+        /// <param name="modelBuilder">The model builder.</param>
+        /// <param name="defaultCollation">The default collation applied to all string columns. Explicit <see cref="CollateAttribute"/>s take precedence.</param>
+        public SqliteDropCreateDatabaseWhenModelChanges(DbModelBuilder modelBuilder, Collation defaultCollation)
+            : this(modelBuilder, typeof(History), defaultCollation)
+        { }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SqliteDropCreateDatabaseWhenModelChanges{TContext}"/> class.
@@ -46,7 +52,17 @@ namespace SQLite.CodeFirst
         /// <param name="modelBuilder">The model builder.</param>
         /// <param name="historyEntityType">Type of the history entity (must implement <see cref="IHistory"/> and provide an parameterless constructor).</param>
         public SqliteDropCreateDatabaseWhenModelChanges(DbModelBuilder modelBuilder, Type historyEntityType)
-            : base(modelBuilder)
+            : this(modelBuilder, historyEntityType, null)
+        { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SqliteDropCreateDatabaseWhenModelChanges{TContext}"/> class.
+        /// </summary>
+        /// <param name="modelBuilder">The model builder.</param>
+        /// <param name="historyEntityType">Type of the history entity (must implement <see cref="IHistory"/> and provide an parameterless constructor).</param>
+        /// <param name="defaultCollation">The default collation applied to all string columns. Explicit <see cref="CollateAttribute"/>s take precedence.</param>
+        public SqliteDropCreateDatabaseWhenModelChanges(DbModelBuilder modelBuilder, Type historyEntityType, Collation defaultCollation)
+            : base(modelBuilder, defaultCollation)
         {
             this.historyEntityType = historyEntityType;
             ConfigureHistoryEntity();


### PR DESCRIPTION
## Summary

The README lists "default collation" as a supported feature: pass a `Collation` as a constructor parameter for an initializer. `SqliteInitializerBase` is fully wired for it (it accepts a `Collation` and feeds it into `SqliteDatabaseCreator`/`SqliteSqlGenerator`), but none of the three concrete initializers forwarded it, leaving `DefaultCollation` always `null`. The feature was therefore unreachable without subclassing the abstract base.

## Changes

Added `Collation`-accepting constructor overloads that forward to `base(modelBuilder, defaultCollation)` on:

- `SqliteCreateDatabaseIfNotExists` — `(modelBuilder, Collation)` and `(modelBuilder, bool, Collation)`
- `SqliteDropCreateDatabaseAlways` — `(modelBuilder, Collation)`
- `SqliteDropCreateDatabaseWhenModelChanges` — `(modelBuilder, Collation)` and `(modelBuilder, Type, Collation)`

All existing constructors are preserved and now chain through the new ones.

## Tests

Added `InitializerDefaultCollationTest` verifying each new overload forwards the collation to `DefaultCollation`, plus a null-default baseline. Full suite green (53 tests).