### PR TITLE
Preserve connection string values containing equals signs

### DIFF
--- a/SQLite.CodeFirst.Test/UnitTests/Utility/ConnectionStringParserTest.cs
+++ b/SQLite.CodeFirst.Test/UnitTests/Utility/ConnectionStringParserTest.cs
@@ -106,5 +106,33 @@ namespace SQLite.CodeFirst.Test.UnitTests.Utility
             // Assert
             Assert.AreEqual(@".\db\footballDb\footballDb.sqlite", result);
         }
+
+        [TestMethod]
+        public void GetDataSource_ReturnsCorrectDataSource_WhenValueContainsEqualsSign()
+        {
+            // Arrange
+            string connectionString = @"data source=.\db\foo=bar\footballDb.sqlite;foreign keys=true";
+
+
+            // Act
+            string result = ConnectionStringParser.GetDataSource(connectionString);
+
+            // Assert
+            Assert.AreEqual(@".\db\foo=bar\footballDb.sqlite", result);
+        }
+
+        [TestMethod]
+        public void GetDataSource_ReturnsLastValue_WhenKeyIsRepeated()
+        {
+            // Arrange
+            string connectionString = @"data source=first.sqlite;data source=second.sqlite";
+
+
+            // Act
+            string result = ConnectionStringParser.GetDataSource(connectionString);
+
+            // Assert
+            Assert.AreEqual(@"second.sqlite", result);
+        }
     }
 }

--- a/SQLite.CodeFirst/Internal/Utility/ConnectionStringParser.cs
+++ b/SQLite.CodeFirst/Internal/Utility/ConnectionStringParser.cs
@@ -42,10 +42,13 @@ namespace SQLite.CodeFirst.Utility
             IDictionary<string, string> keyValuePairDictionary = new Dictionary<string, string>();
             foreach (var keyValuePair in keyValuePairs)
             {
-                string[] keyValue = keyValuePair.Split(KeyValueSeperator);
+                // Split on the first '=' only so a value that itself contains '=' is preserved.
+                // Input:  "data source=C:\a=b.sqlite"  ->  key="data source", value="C:\a=b.sqlite"
+                string[] keyValue = keyValuePair.Split(new[] { KeyValueSeperator }, 2, StringSplitOptions.None);
                 if (keyValue.Length >= 2)
                 {
-                    keyValuePairDictionary.Add(keyValue[KeyPosition].Trim().ToLower(CultureInfo.InvariantCulture), keyValue[ValuePosition]);
+                    // Indexer assignment (last value wins) so a repeated key does not throw.
+                    keyValuePairDictionary[keyValue[KeyPosition].Trim().ToLower(CultureInfo.InvariantCulture)] = keyValue[ValuePosition];
                 }
             }
 


### PR DESCRIPTION
## Summary

`ConnectionStringParser.ParseConnectionString` split each `key=value` pair on every `=` and kept only `keyValue[1]`. A `Data Source` whose value contains `=` (a file path, or a `FullUri` with query parameters) was truncated at the first `=`. A repeated key also threw because the dictionary was populated with `Add`.

## Changes

- Split each pair on the first `=` only (`Split(separator, 2, StringSplitOptions.None)`), preserving the rest of the value. Available on net40/net45/netstandard2.1.
- Populate the dictionary via the indexer (last value wins) instead of `Add`, so a repeated key does not throw.

## Tests

Added `ConnectionStringParserTest` cases for a `Data Source` value containing `=` and for a repeated key. Full suite green (49 tests).