### PR TITLE
Minor correctness and clarity cleanups

### DIFF
--- a/SQLite.CodeFirst/Internal/Convention/SqliteForeignKeyIndexConvention.cs
+++ b/SQLite.CodeFirst/Internal/Convention/SqliteForeignKeyIndexConvention.cs
@@ -74,16 +74,16 @@ namespace SQLite.CodeFirst.Convention
 
         private static IndexAnnotation CreateIndexAnnotation(string tableName, string propertyName, int count)
         {
-            var indexName = IndexNameCreator.CreateName(tableName, propertyName);
+            // If there are two indices on the same property, the count is appended.
+            // In SQLite an index name must be globally unique.
+            // To be honest, it should never happen. But because it is possible via the API, it is covered.
+            // The suffix is folded in before escaping so it stays inside the quoted identifier;
+            // IndexNameCreator.CreateName returns an already-escaped name.
+            string uniquePropertyName = count > 0
+                ? String.Format(CultureInfo.InvariantCulture, "{0}_{1}", propertyName, count)
+                : propertyName;
 
-            // If there are two Indicies on the same property, the count is added.
-            // In SQLite an Index name must be global unique.
-            // To be honest, it should never happen. But because its possible by using the API, it should be covered.
-            if (count > 0)
-            {
-                indexName = String.Format(CultureInfo.InvariantCulture, "{0}_{1}", indexName, count);
-            }
-
+            var indexName = IndexNameCreator.CreateName(tableName, uniquePropertyName);
             var indexAttribute = new IndexAttribute(indexName);
             return new IndexAnnotation(indexAttribute);
         }

--- a/SQLite.CodeFirst/Internal/Utility/AssociationTypeContainer.cs
+++ b/SQLite.CodeFirst/Internal/Utility/AssociationTypeContainer.cs
@@ -10,7 +10,9 @@ namespace SQLite.CodeFirst.Utility
 
         public AssociationTypeContainer(IEnumerable<AssociationType> associationTypes, EntityContainer container)
         {
-            sqliteAssociationTypes = associationTypes.Select(associationType => new SqliteAssociationType(associationType, container));
+            // Materialize once. GetAssociationTypes is called per entity set, so a deferred query
+            // would rebuild every SqliteAssociationType (and its entity-set lookups) on each call.
+            sqliteAssociationTypes = associationTypes.Select(associationType => new SqliteAssociationType(associationType, container)).ToList();
         }
 
         public IEnumerable<SqliteAssociationType> GetAssociationTypes(string entitySetName)

--- a/SQLite.CodeFirst/Internal/Utility/ConnectionStringParser.cs
+++ b/SQLite.CodeFirst/Internal/Utility/ConnectionStringParser.cs
@@ -21,7 +21,7 @@ namespace SQLite.CodeFirst.Utility
             IDictionary<string, string> strings = ParseConnectionString(connectionString);
             if (strings.ContainsKey(DataSourceToken))
             {
-                var path = ExpandDataDirectory(ParseConnectionString(connectionString)[DataSourceToken]);
+                var path = ExpandDataDirectory(strings[DataSourceToken]);
                 return path.Trim('"');
             }
 


### PR DESCRIPTION
## Summary

Three small, behavior-preserving cleanups surfaced during the correctness review.

## Changes

- **AssociationTypeContainer**: materialize the `Select` projection with `ToList()`. `GetAssociationTypes` is called once per entity set; the deferred query previously rebuilt every `SqliteAssociationType` (and its entity-set lookups) on each call.
- **ConnectionStringParser.GetDataSource**: reuse the dictionary already returned by `ParseConnectionString` instead of parsing the connection string a second time.
- **SqliteForeignKeyIndexConvention**: when disambiguating duplicate indices on the same property, fold the `_{count}` suffix into the property name *before* escaping. `IndexNameCreator.CreateName` returns an already-quoted identifier, so the old code appended the suffix after the closing quote (`"IX_T_P"_1`); it now stays inside the quotes (`"IX_T_P_1"`). The normal (`count == 0`) path is unchanged.

## Tests

No new tests: the first two are pure refactors covered by the existing suite, and the third only changes the "should never happen" duplicate-index path while leaving normal output identical (verified by the unchanged SQL-generation reference tests). Full suite green (47 tests).